### PR TITLE
add workaround for old gcc

### DIFF
--- a/include/hprose_reader.h
+++ b/include/hprose_reader.h
@@ -27,6 +27,15 @@
 #include "hprose_class_manager.h"
 #include "hprose_raw_reader.h"
 
+/* Workaround for old gcc. */
+#ifndef NAN
+#define NAN (0.0/0.0)
+#endif
+#ifndef INFINITY
+#define INFINITY (1.0/0.0)
+#endif
+
+
 BEGIN_EXTERN_C()
 
 zend_class_entry *get_hprose_reader_ce();


### PR DESCRIPTION
At least on RHEL-5

```
 include/hprose_reader.h:235: error: 'INFINITY' undeclared (first use in this function)
 hprose_reader.h:264: error: 'NAN' undeclared (first use in this function)
```

With this workaround, build + test suite are ok.
