### PR TITLE
Fix for PHP 7.4

### DIFF
--- a/hprose_common.h
+++ b/hprose_common.h
@@ -607,9 +607,11 @@ static zend_always_inline zend_bool hprose_has_property(zend_class_entry *ce, zv
 #else
     zend_string *name = Z_STR_P(prop);
     if ((property_info = zend_hash_find_ptr(&ce->properties_info, name)) != NULL) {
+#if PHP_VERSION_ID < 70400
         if (property_info->flags & ZEND_ACC_SHADOW) {
             return 0;
         }
+#endif
         return 1;
     }
     else {


### PR DESCRIPTION
From UPGRAGING.INTERNALS

>     - ZEND_ACC_SHADOW property flag is removed. Instead of creating shadow
>       clone, now we use the same private property_info, and should also
>       check property_info->ce (in the same way as with methods).
> 

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   15
---------------------------------------------------------------------

Number of tests :    8                 8
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :    8 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================

```